### PR TITLE
fixing ajax ambiguous likes_count

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -40,8 +40,10 @@
               var newLikes;
               if (data.liked){
                   updateText(this_, addLike, "Unlike")
+                  this_.attr("data-likes", addLike)
               } else {
                   updateText(this_, removeLike, "Like")
+                  this_.attr("data-likes", removeLike)
                   // remove one like
               }
 


### PR DESCRIPTION
The onClick function on like button was not updating the 'data-likes' attribute, thus, the var 'likeCount' always remained constant. Hence, the updating of likes_count has been added.